### PR TITLE
Custom nodes are now installed on the host system

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -2,8 +2,8 @@
     // Version of the settings file, this should always be 0.2
     "version": "0.2",
 
-    // The code in this repository is checked against British English, American English, and German
-    "language": "en-gb,en-us,de-de",
+    // The code in this repository is checked against British English and American English
+    "language": "en-gb,en-us",
 
     // A list of file types that should be enabled (not all file types are enabled by default)
     "enableFiletypes": [
@@ -21,7 +21,7 @@
         "source/PersonalWebsite/Assets/libraries/**/*"
     ],
 
-    // A list of dictionaries that should be added beyond the American English dictionary
+    // A list of dictionaries that should be added beyond the British English and American English dictionaries
     "dictionaries": [
 
         // Dictionaries that contain common misspellings
@@ -32,11 +32,8 @@
         // Dictionaries that contain the keywords of the programming, markup, styling, and configuration languages used in the project
         "docker",
 
-        // Other dictionaries, that contain the names of well-known companies, common acronyms related to computing, words used in data science,
-        // common file extensions, common font names that may be used in CSS, common words often encountered in full-stack development, the
-        // popular blind text Lorem Ipsum often used for testing text layout, terms common in computer networking, the most popular NPM packages that
-        // may be used in Angular projects, terms used in popular public licenses, common software terms, and miscellaneous terms that are common in
-        // software projects
+        // Other dictionaries, that contain sub-specific words and names
+        // projects
         "companies",
         "computing-acronyms",
         "data-science",
@@ -65,8 +62,17 @@
     // A list of words that are not in the included default dictionary for British English, American English, or German
     "words": [
         "comfyui",
+        "controlnet",
         "cudnn",
+        "findall",
+        "gligen",
+        "hypernetworks",
         "lecode",
+        "loras",
+        "photomaker",
+        "PYTHONPATH",
+        "pytorch",
+        "unet",
         "vsicons"
     ]
 }

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -40,6 +40,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      # Installs Python, which is used to extract the version of ComfyUI and the ComfyUI Manager from the Dockerfile using a regular expression
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
       # Logs in to the GitHub Container Registry registry using the account of the user that triggered the workflow run and the GitHub token that is
       # an automatically generated secret that is usually only used to access the repository (the permissions defined above allow the token to also
       # publish Docker images to the GitHub Container Registry) that will publish the packages. Once published, the packages are scoped to the account defined here.
@@ -50,6 +56,29 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Extracts the versions of ComfyUI and the ComfyUI Manager from the Dockerfile using a Python script; the versions are written to the output
+      # file, which are available in subsequent steps under steps.versions.outputs.COMFYUI_VERSION and steps.versions.outputs.COMFYUI_MANAGER_VERSION;
+      # the versions are used to tag the Docker image, so that users know which versions of ComfyUI and the ComfyUI Manager are included in the image
+      - name: Extract ComfyUI & ComfyUI Manager Versions
+        id: versions
+        shell: python
+        run: |
+          import os
+          import re
+
+          def get_version(repository_name: str) -> str:
+            with open('Dockerfile', mode='r', encoding='utf-8') as dockerfile:
+                matches = re.findall(
+                  rf'git clone [a-zA-Z0-9:\/\.]+\/{repository_name}\.git[a-zA-Z0-9\-\/&\\\n ]+git checkout tags\/v?([0-9\.]+)',
+                  dockerfile.read(),
+                  re.MULTILINE
+                )
+                return matches[0] if matches else 'unknown'
+
+          with open(os.environ['GITHUB_OUTPUT'], mode='a', encoding='utf-8') as output_file:
+            output_file.write(f'COMFYUI_VERSION={get_version('ComfyUI')}\n')
+            output_file.write(f'COMFYUI_MANAGER_VERSION={get_version('ComfyUI-Manager')}\n')
+
       # Extracts metadata from the Git repository and GitHub, which are then used to label and tag the Docker image that will be build in the next
       # step; the "id" property specifies that the output of this step will be available in subsequent steps under the name "metadata"; tags for the
       # SHA of the commit, the full semantic version extracted from the current tag (e.g., tag "v1.2.3" will be extracted as "1.2.3"), and the major
@@ -57,14 +86,16 @@ jobs:
       # besides the hardcoded labels for the title and authors of the image, the GitHub description, GitHub license, GitHub revision, GitHub source
       # URL, GitHub URL, and creation date and time are extracted as labels
       - name: Extract Tags & Labels for Docker
-        id: metadata
+        id: docker-image-metadata
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=sha
-            type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{version}}-comfyui-${{ steps.versions.outputs.COMFYUI_VERSION }}
+            type=semver,pattern={{version}}-comfyui-${{ steps.versions.outputs.COMFYUI_VERSION }}-comfyui-manager-${{ steps.versions.outputs.COMFYUI_MANAGER_VERSION }}
           labels: |
             org.opencontainers.image.title=ComfyUI Docker
             org.opencontainers.image.authors=David Neumann <david.neumann@lecode.de>
@@ -73,13 +104,13 @@ jobs:
       # the build context, which is the directory that contains the Dockerfile; the tags and labels extracted in the previous step are used to tag
       # and label the image
       - name: Build and Push Docker Image
-        id: push
+        id: build-and-push-docker-image
         uses: docker/build-push-action@v6
         with:
           context: .
           push: true
-          tags: ${{ steps.metadata.outputs.tags }}
-          labels: ${{ steps.metadata.outputs.labels }}
+          tags: ${{ steps.docker-image-metadata.outputs.tags }}
+          labels: ${{ steps.docker-image-metadata.outputs.labels }}
 
       # Generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built; it increases supply chain
       # security for people who consume the image
@@ -87,5 +118,5 @@ jobs:
         uses: actions/attest-build-provenance@v1
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
-          subject-digest: ${{ steps.push.outputs.digest }}
+          subject-digest: ${{ steps.build-and-push-docker-image.outputs.digest }}
           push-to-registry: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+## v0.2.0 (December 16, 2024)
+
+- Previously, only the model files were stored outside of the container, but the custom nodes installed by ComfyUI Manager were not. The reason was that the ComfyUI Manager itself is implemented as a custom node, which means that mounting a host system directory into the custom nodes directory would hide the ComfyUI Manager. This problem was fixed by installing the ComfyUI Manager in a separate directory and symlinking it upon container startup into the mounted directory.
+- Updated the image to the latest version of ComfyUI (from v0.3.4 to v0.3.7).
+- In the previous version, the main branch of the ComfyUI Manager was installed and not a specific version. Since the main branch may contain breaking changes or bugs, the ComfyUI Manager is now installed with a specific version (v2.55.5).
+- The ComfyUI Manager installs its dependencies when it is first launched. This means that the dependencies have to be installed every time the container is started. To avoid this, the dependencies are now installed manually during the image build process.
+- The directory structure of the ComfyUI models directory is now automatically created upon container startup if it does not exist.
+- The Docker image now has two more tags: one with the ComfyUI version and the second with the ComfyUI and ComfyUI Manager versions that are installed in the image. This makes it easier for users to find out which ComfyUI version they are installing before pulling the image.
+- A section was added to the read me, which explains how to update the local image to the latest version.
+
+## v0.1.0 (November 28, 2024)
+
+- Created a Docker image for running ComfyUI.
+- The image includes ComfyUI and ComfyUI Manager.
+- The image is based on the latest version of the PyTorch image.
+- A GitHub Actions workflow is used to automatically build and publish the Docker image to the GitHub Container Registry when a release is created.

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,24 +7,38 @@ RUN apt update --assume-yes && \
     apt install --assume-yes git
 
 # Clones the ComfyUI repository and checks out the latest release
-RUN git clone https://github.com/comfyanonymous/ComfyUI.git  /opt/comfyui && \
+RUN git clone https://github.com/comfyanonymous/ComfyUI.git /opt/comfyui && \
     cd /opt/comfyui && \
-    git checkout tags/v0.3.4
+    git checkout tags/v0.3.7
+
+# Clones the ComfyUI Manager repository and checks out the latest release; ComfyUI Manager is an extension for ComfyUI that enables users to install
+# custom nodes and download models directly from the ComfyUI interface; instead of installing it to "/opt/comfyui/custom_nodes/ComfyUI-Manager", which
+# is the directory it is meant to be installed in, it is installed to its own directory; the entrypoint will symlink the directory to the correct
+# location upon startup; the reason for this is that the ComfyUI Manager must be installed in the same directory that it installs custom nodes to, but
+# this directory is mounted as a volume, so that the custom nodes are not installed inside of the container and are not lost when the container is
+# removed; this way, the custom nodes are installed on the host machine
+RUN git clone https://github.com/ltdrdata/ComfyUI-Manager.git /opt/comfyui-manager && \
+    cd /opt/comfyui-manager && \
+    git checkout tags/2.55.5
+
+# Installs the required Python packages for both ComfyUI and the ComfyUI Manager
+RUN pip install \
+    --requirement /opt/comfyui/requirements.txt \
+    --requirement /opt/comfyui-manager/requirements.txt
 
 # Sets the working directory to the ComfyUI directory
 WORKDIR /opt/comfyui
-
-# Installs the required Python packages
-RUN pip install -r requirements.txt
-
-# Installs the ComfyUI Manager, which is an extension for ComfyUI that makes it possible to install, remove, disable, and enable various custom nodes
-RUN git clone https://github.com/ltdrdata/ComfyUI-Manager.git custom_nodes/ComfyUI-Manager
 
 # Exposes the default port of ComfyUI (this is not actually exposing the port to the host machine, but it is good practice to include it as metadata,
 # so that the user knows which port to publish)
 EXPOSE 8188
 
+# Adds the startup script to the container; the startup script will create all necessary directories in the models and custom nodes volumes that were
+# mounted to the container and symlink the ComfyUI Manager to the correct directory
+ADD entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
+
 # On startup, ComfyUI is started at its default port; the IP address is changed from localhost to 0.0.0.0, because Docker is only forwarding traffic
 # to the IP address it assigns to the container, which is unknown at build time; listening to 0.0.0.0 means that ComfyUI listens to all incoming
 # traffic; the auto-launch feature is disabled, because we do not want (nor is it possible) to open a browser window in a Docker container
-CMD ["python", "main.py", "--listen", "0.0.0.0", "--port", "8188", "--disable-auto-launch"]
+CMD ["/opt/conda/bin/python", "main.py", "--listen", "0.0.0.0", "--port", "8188", "--disable-auto-launch"]

--- a/README.md
+++ b/README.md
@@ -17,14 +17,15 @@ docker run \
     --name comfyui \
     --detach \
     --restart unless-stopped \
-    --volume <path/to/models/folder>:/opt/comfyui/models \
+    --volume "<path/to/models/folder>:/opt/comfyui/models:rw" \
+    --volume "<path/to/custom/nodes/folder>:/opt/comfyui/custom_nodes:rw" \
     --publish 8188:8188 \
     --runtime nvidia \
     --gpus all \
     ghcr.io/lecode-official/comfyui-docker:latest
 ```
 
-Please note, that the `<path/to/models/folder>` must be replaced with a path to a folder on the host system where the models will be stored, e.g., `$HOME/.comfyui`.
+Please note, that the `<path/to/models/folder>` and `<path/to/custom/nodes/folder>` must be replaced with paths to directories on the host system where the models and custom nodes will be stored, e.g., `$HOME/.comfyui/models` and `$HOME/.comfyui/custom-nodes`, which can be created like so: `mkdir -p $HOME/.comfyui/{models,custom-nodes}`.
 
 The `--detach` flag causes the container to run in the background and `--restart unless-stopped` configures the Docker Engine to automatically restart the container if it stopped itself, experienced an error, or the computer was shutdown, unless you explicitly stopped the container using `docker stop`. This means that ComfyUI will be automatically started in the background when you boot your computer. The `--runtime nvidia` and `--gpus all` arguments enable ComfyUI to access the GPUs of your host system. If you do not want to expose all GPUs, you can specify the desired GPU index or ID instead.
 
@@ -35,6 +36,29 @@ If you want to stop ComfyUI, you can use the following commands:
 ```shell
 docker stop comfyui
 docker rm comfyui
+```
+
+## Updating
+
+To update ComfyUI Docker to the latest version you have to first stop the running container, then pull the new version, optionally remove dangling images, and then restart the container:
+
+```shell
+docker stop comfyui
+docker rm comfyui
+
+docker pull ghcr.io/lecode-official/comfyui-docker:latest
+docker image prune # Optionally remove dangling images
+
+docker run \
+    --name comfyui \
+    --detach \
+    --restart unless-stopped \
+    --volume "<path/to/models/folder>:/opt/comfyui/models:rw" \
+    --volume "<path/to/custom/nodes/folder>:/opt/comfyui/custom_nodes:rw" \
+    --publish 8188:8188 \
+    --runtime nvidia \
+    --gpus all \
+    ghcr.io/lecode-official/comfyui-docker:latest
 ```
 
 ## Building
@@ -53,7 +77,8 @@ docker run \
     --name comfyui \
     --detach \
     --restart unless-stopped \
-    --volume <path/to/models/folder>:/opt/comfyui/models \
+    --volume "<path/to/models/folder>:/opt/comfyui/models:rw" \
+    --volume "<path/to/custom/nodes/folder>:/opt/comfyui/custom_nodes:rw" \
     --publish 8188:8188 \
     --runtime nvidia \
     --gpus all \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Creates the directories for the models inside of the volume that is mounted from the host
+MODEL_DIRECTORIES=(
+    "checkpoints"
+    "clip"
+    "clip_vision"
+    "configs"
+    "controlnet"
+    "diffusers"
+    "diffusion_models"
+    "embeddings"
+    "gligen"
+    "hypernetworks"
+    "loras"
+    "photomaker"
+    "style_models"
+    "text_encoders"
+    "unet"
+    "upscale_models"
+    "vae"
+    "vae_approx"
+)
+for MODEL_DIRECTORY in ${MODEL_DIRECTORIES[@]}; do
+    mkdir -p /opt/comfyui/models/$MODEL_DIRECTORY
+done
+
+# Creates the symlink for the ComfyUI Manager to the custom nodes directory, which is also mounted from the host
+rm --force /opt/comfyui/custom_nodes/ComfyUI-Manager
+ln -s \
+    /opt/comfyui-manager \
+    /opt/comfyui/custom_nodes/ComfyUI-Manager


### PR DESCRIPTION
Previously, only the model files were stored outside of the container, but the custom nodes installed by ComfyUI Manager were not. The reason was that the ComfyUI Manager itself is implemented as a custom node, which means that mounting a host system directory into the custom nodes directory would hide the ComfyUI Manager. This problem was fixed by installing the ComfyUI Manager in a separate directory and symlinking it upon container startup into the mounted directory.

Furthermore, the following changes were made:

- Updated the image to the latest version of ComfyUI (from v0.3.4 to v0.3.7).
- In the previous version, the main branch of the ComfyUI Manager was installed and not a specific version. Since the main branch may contain breaking changes or bugs, the ComfyUI Manager is now installed with a specific version (v2.55.5).
- The ComfyUI Manager installs its dependencies when it is first launched. This means that the dependencies have to be installed every time the container is started. To avoid this, the dependencies are now installed manually during the image build process.
- The directory structure of the ComfyUI models directory is now automatically created upon container startup if it does not exist.
- The Docker image now has two more tags: one with the ComfyUI version and the second with the ComfyUI and ComfyUI Manager versions that are installed in the image. This makes it easier for users to find out which ComfyUI version they are installing before pulling the image.
- A section was added to the read me, which explains how to update the local image to the latest version.

Closes #1.