### PR TITLE
Release v0.3.0

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -67,12 +67,17 @@
         "findall",
         "getent",
         "gligen",
+        "glx",
         "hypernetworks",
         "lecode",
+        "libgl",
+        "libglib",
+        "libgthread",
         "loras",
         "photomaker",
         "PYTHONPATH",
         "pytorch",
+        "Subpack",
         "unet",
         "vsicons"
     ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.3.0 (March 24, 2025)
+
+- Updated the base image of the Dockerfile to the latest version of PyTorch (from PyTorch 2.5.1, CUDA 12.4 and cuDNN 9 to PyTorch 2.6.0 CUDA 12.4 and cuDNN 9).
+- Updated the ComfyUI version to the latest version (from ComfyUI 0.3.7 to ComfyUI 0.3.27).
+- Updated the ComfyUI Manager version to the latest version (from ComfyUI Manager 2.55.5 to ComfyUI Manager 3.31.8).
+- Installed the packages `libgl1-mesa-glx` and `libglib2.0-0`, which will hopefully fix issues with the ComfyUI Impact Pack, ComfyUI Impact Subpack, and ComfyUI Inspire Pack custom nodes that were missing the `libGL.so.1` and `libgthread-2.0.so.0` libraries.
+- The APT cache is now being cleaned after installing the packages to reduce the image size.
+
 ## v0.2.0 (December 16, 2024)
 
 - Previously, only the model files were stored outside of the container, but the custom nodes installed by ComfyUI Manager were not. The reason was that the ComfyUI Manager itself is implemented as a custom node, which means that mounting a host system directory into the custom nodes directory would hide the ComfyUI Manager. This problem was fixed by installing the ComfyUI Manager in a separate directory and symlinking it upon container startup into the mounted directory.

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,10 @@ FROM pytorch/pytorch:2.6.0-cuda12.4-cudnn9-runtime
 RUN apt update --assume-yes && \
     apt install --assume-yes \
         git \
-        sudo
+        sudo \
+        libgl1-mesa-glx \
+        libglib2.0-0 && \
+    rm -rf /var/lib/apt/lists/*
 
 # Clones the ComfyUI repository and checks out the latest release
 RUN git clone https://github.com/comfyanonymous/ComfyUI.git /opt/comfyui && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 
 # This image is based on the latest official PyTorch image, because it already contains CUDA, CuDNN, and PyTorch
-FROM pytorch/pytorch:2.5.1-cuda12.4-cudnn9-runtime
+FROM pytorch/pytorch:2.6.0-cuda12.4-cudnn9-runtime
 
 # Installs Git, because ComfyUI and the ComfyUI Manager are installed by cloning their respective Git repositories
 RUN apt update --assume-yes && \
@@ -11,7 +11,7 @@ RUN apt update --assume-yes && \
 # Clones the ComfyUI repository and checks out the latest release
 RUN git clone https://github.com/comfyanonymous/ComfyUI.git /opt/comfyui && \
     cd /opt/comfyui && \
-    git checkout tags/v0.3.7
+    git checkout tags/v0.3.27
 
 # Clones the ComfyUI Manager repository and checks out the latest release; ComfyUI Manager is an extension for ComfyUI that enables users to install
 # custom nodes and download models directly from the ComfyUI interface; instead of installing it to "/opt/comfyui/custom_nodes/ComfyUI-Manager", which
@@ -21,7 +21,7 @@ RUN git clone https://github.com/comfyanonymous/ComfyUI.git /opt/comfyui && \
 # removed; this way, the custom nodes are installed on the host machine
 RUN git clone https://github.com/ltdrdata/ComfyUI-Manager.git /opt/comfyui-manager && \
     cd /opt/comfyui-manager && \
-    git checkout tags/2.55.5
+    git checkout tags/3.31.8
 
 # Installs the required Python packages for both ComfyUI and the ComfyUI Manager
 RUN pip install \


### PR DESCRIPTION
- Updated the base image of the Dockerfile to the latest version of PyTorch (from PyTorch 2.5.1, CUDA 12.4 and cuDNN 9 to PyTorch 2.6.0 CUDA 12.4 and cuDNN 9).
- Updated the ComfyUI version to the latest version (from ComfyUI 0.3.7 to ComfyUI 0.3.27).
- Updated the ComfyUI Manager version to the latest version (from ComfyUI Manager 2.55.5 to ComfyUI Manager 3.31.8).
- Installed the packages `libgl1-mesa-glx` and `libglib2.0-0`, which will hopefully fix issues with the ComfyUI Impact Pack, ComfyUI Impact Subpack, and ComfyUI Inspire Pack custom nodes that were missing the `libGL.so.1` and `libgthread-2.0.so.0` libraries.
- The APT cache is now being cleaned after installing the packages to reduce the image size.

Closes issues #9 and #7.