### PR TITLE
Adding to the comment about the usage of `--enable-cors-headers` for separate web applications

### DIFF
--- a/source/Dockerfile
+++ b/source/Dockerfile
@@ -53,5 +53,7 @@ ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 # On startup, ComfyUI is started at its default port; the IP address is changed from localhost to 0.0.0.0, because Docker is only forwarding traffic
 # to the IP address it assigns to the container, which is unknown at build time; listening to 0.0.0.0 means that ComfyUI listens to all incoming
-# traffic; the auto-launch feature is disabled, because we do not want (nor is it possible) to open a browser window in a Docker container
+# traffic; the auto-launch feature is disabled, because we do not want (nor is it possible) to open a browser window in a Docker container. To allow
+# a separate web application to interact with this container, you may need to enable CORS which can be done by adding the --enable-cors-header [ORIGIN]
+# flag to the command.
 CMD ["/opt/conda/bin/python", "main.py", "--listen", "0.0.0.0", "--port", "8188", "--disable-auto-launch"]


### PR DESCRIPTION
I was going through some old code and came across I change I had to make to `Dockerfile` when deploying a container that interacted with a separate web application. Instead of including the flag into your default configuration, I though I would just update the comment to notify other users who may find it useful.