### PR TITLE
Release v0.5.0

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -70,6 +70,7 @@
         "getent",
         "gligen",
         "glx",
+        "Hamade",
         "Harmsel",
         "hypernetworks",
         "Kranz",

--- a/.cspell.json
+++ b/.cspell.json
@@ -72,6 +72,7 @@
         "glx",
         "Harmsel",
         "hypernetworks",
+        "Kranz",
         "lecode",
         "libgl",
         "libglib",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -50,7 +50,7 @@
     "cSpell.ignorePaths": [],
     "cSpell.useGitignore": false,
     "cSpell.diagnosticLevel": "Error",
-    "cSpell.import": [".cspell.json"],
+    "cSpell.import": ["${workspaceFolder}/.cspell.json"],
 
     // Configures the icon theme to be VSCode Icons and adapts the icons of certain files and directories for the VSCode Icons plugin
     "workbench.iconTheme": "vscode-icons",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.5.0 (August 12, 2025)
+
+- The ComfyUI Manager repository has been moved to a new organization and therefore, the URL from which it can be cloned has changed. This URL was updated in the Dockerfile.
+- It is now possible to pass additional command line arguments to ComfyUI in the `docker run` command. This was done by moving the `CMD` from the Dockerfile to the `entrypoint.sh` script. Now, users can specify additional command line arguments when starting the container as the command, which are then passed to ComfyUI. The read me was updated to showcase this.
+- In the read me, the commands for building and running the image locally had a small issue: After cloning the repository, the current directory was not changed to the cloned repository, which would lead to an error when building the image. This was fixed by adding a `cd comfyui-docker` command after the `git clone` command.
+- This version of ComfyUI Docker was made possible by the contributions of [Patrick Kranz](@LokiMidgard) and [Alex Reynolds](@primlock).
+
 ## v0.4.0 (June 16, 2025)
 
 - Updated the base image of the Dockerfile to the latest version of PyTorch (from PyTorch 2.6.0, CUDA 12.4, and cuDNN 9 to PyTorch 2.7.1, CUDA 12.6, and cuDNN 9).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@
 - The ComfyUI Manager repository has been moved to a new organization and therefore, the URL from which it can be cloned has changed. This URL was updated in the Dockerfile.
 - It is now possible to pass additional command line arguments to ComfyUI in the `docker run` command. This was done by moving the `CMD` from the Dockerfile to the `entrypoint.sh` script. Now, users can specify additional command line arguments when starting the container as the command, which are then passed to ComfyUI. The read me was updated to showcase this.
 - In the read me, the commands for building and running the image locally had a small issue: After cloning the repository, the current directory was not changed to the cloned repository, which would lead to an error when building the image. This was fixed by adding a `cd comfyui-docker` command after the `git clone` command.
-- This version of ComfyUI Docker was made possible by the contributions of [Patrick Kranz](@LokiMidgard) and [Alex Reynolds](@primlock).
+- Updated the base image of the Dockerfile to the latest version of PyTorch (from PyTorch 2.7.1, CUDA 12.6, and cuDNN 9 to PyTorch 2.8.0, CUDA 12.9, and cuDNN 9).
+- Updated the ComfyUI version to the latest version (from ComfyUI 0.3.40 to ComfyUI 0.3.49).
+- Updated the ComfyUI Manager version to the latest version (from ComfyUI Manager 3.33 to ComfyUI Manager 3.35).
+- This version of ComfyUI Docker was made possible by the contributions of [Patrick Kranz](@LokiMidgard), [Alex Reynolds](@primlock), and [Mustafa Hamade](@Mustafa-Hamade).
 
 ## v0.4.0 (June 16, 2025)
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2,6 +2,7 @@
 
 This file contains a list of contributors to the ComfyUI Docker project.
 
+- [Alex Reynolds](@primlock) (#22)
 - [Chris TenHarmsel](@epchris) (#13)
 - [David Neumann](@lecode-official) (#3, #4, #5, #10, #11, #12, #17, #18)
 - [Patrick Kranz](@LokiMidgard) (#21)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,4 +5,5 @@ This file contains a list of contributors to the ComfyUI Docker project.
 - [Alex Reynolds](@primlock) (#22)
 - [Chris TenHarmsel](@epchris) (#13)
 - [David Neumann](@lecode-official) (#3, #4, #5, #10, #11, #12, #17, #18)
+- [Mustafa Hamade](@Mustafa-Hamade) (#20)
 - [Patrick Kranz](@LokiMidgard) (#21)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -3,4 +3,5 @@
 This file contains a list of contributors to the ComfyUI Docker project.
 
 - [Chris TenHarmsel](@epchris) (#13)
-- [David Neumann](@lecode-official) (#3, #4, #5, #10, #11, #12)
+- [David Neumann](@lecode-official) (#3, #4, #5, #10, #11, #12, #17, #18)
+- [Patrick Kranz](@LokiMidgard) (#21)

--- a/README.md
+++ b/README.md
@@ -68,12 +68,31 @@ docker run \
     ghcr.io/lecode-official/comfyui-docker:latest
 ```
 
+If you want to pass additional command line arguments to ComfyUI, you can do so by specifying them as the command when starting the container. For example, if you want to allow external web apps to connect to ComfyUI in the container, you can add the `--enable-cors-header` argument like so:
+
+```shell
+docker run \
+    --name comfyui \
+    --detach \
+    --restart unless-stopped \
+    --env USER_ID="$(id -u)" \
+    --env GROUP_ID="$(id -g)" \
+    --volume "<path/to/models/folder>:/opt/comfyui/models:rw" \
+    --volume "<path/to/custom/nodes/folder>:/opt/comfyui/custom_nodes:rw" \
+    --publish 8188:8188 \
+    --runtime nvidia \
+    --gpus all \
+    ghcr.io/lecode-official/comfyui-docker:latest \
+    --enable-cors-header <origin>
+```
+
 ## Building
 
 If you want to use the bleeding edge development version of the Docker image, you can also clone the repository and build the image yourself:
 
 ```shell
 git clone https://github.com/lecode-official/comfyui-docker.git
+cd comfyui-docker
 docker build --tag lecode/comfyui-docker:latest source
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ComfyUI Docker
 
-This is a Docker image for [ComfyUI](https://www.comfy.org/), which makes it extremely easy to run ComfyUI on Linux and Windows WSL2. The image also includes the [ComfyUI Manager](https://github.com/ltdrdata/ComfyUI-Managergithub ) extension.
+This is a Docker image for [ComfyUI](https://www.comfy.org/), which makes it extremely easy to run ComfyUI on Linux and Windows WSL2. The image also includes the [ComfyUI Manager](https://github.com/Comfy-Org/ComfyUI-Manager) extension.
 
 ## Getting Started
 

--- a/source/Dockerfile
+++ b/source/Dockerfile
@@ -50,10 +50,3 @@ EXPOSE 8188
 # that started the container, so that the files created by the container are owned by the user that started the container and not the root user
 ADD entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
-
-# On startup, ComfyUI is started at its default port; the IP address is changed from localhost to 0.0.0.0, because Docker is only forwarding traffic
-# to the IP address it assigns to the container, which is unknown at build time; listening to 0.0.0.0 means that ComfyUI listens to all incoming
-# traffic; the auto-launch feature is disabled, because we do not want (nor is it possible) to open a browser window in a Docker container. To allow
-# a separate web application to interact with this container, you may need to enable CORS which can be done by adding the --enable-cors-header [ORIGIN]
-# flag to the command.
-CMD ["/opt/conda/bin/python", "main.py", "--listen", "0.0.0.0", "--port", "8188", "--disable-auto-launch"]

--- a/source/Dockerfile
+++ b/source/Dockerfile
@@ -1,8 +1,8 @@
 
 # Defines the versions of ComfyUI, ComfyUI Manager, and PyTorch to use
-ARG COMFYUI_VERSION=v0.3.40
-ARG COMFYUI_MANAGER_VERSION=3.33
-ARG PYTORCH_VERSION=2.7.1-cuda12.6-cudnn9-runtime
+ARG COMFYUI_VERSION=v0.3.49
+ARG COMFYUI_MANAGER_VERSION=3.35
+ARG PYTORCH_VERSION=2.8.0-cuda12.9-cudnn9-runtime
 
 # This image is based on the latest official PyTorch image, because it already contains CUDA, CuDNN, and PyTorch
 FROM pytorch/pytorch:${PYTORCH_VERSION}

--- a/source/Dockerfile
+++ b/source/Dockerfile
@@ -53,5 +53,7 @@ ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 # On startup, ComfyUI is started at its default port; the IP address is changed from localhost to 0.0.0.0, because Docker is only forwarding traffic
 # to the IP address it assigns to the container, which is unknown at build time; listening to 0.0.0.0 means that ComfyUI listens to all incoming
-# traffic; the auto-launch feature is disabled, because we do not want (nor is it possible) to open a browser window in a Docker container
+# traffic; the auto-launch feature is disabled, because we do not want (nor is it possible) to open a browser window in a Docker container. To allow
+# a separate web application to interact with this container, you may need to enable CORS which can be done by adding the --enable-cors-header [ORIGIN]
+# flag to the command.
 CMD ["/opt/conda/bin/python", "main.py", "--listen", "0.0.0.0", "--port", "8188", "--disable-auto-launch"]


### PR DESCRIPTION
- The ComfyUI Manager repository has been moved to a new organization and therefore, the URL from which it can be cloned has changed. This URL was updated in the Dockerfile.
- It is now possible to pass additional command line arguments to ComfyUI in the `docker run` command. This was done by moving the `CMD` from the Dockerfile to the `entrypoint.sh` script. Now, users can specify additional command line arguments when starting the container as the command, which are then passed to ComfyUI. The read me was updated to showcase this.
- In the read me, the commands for building and running the image locally had a small issue: After cloning the repository, the current directory was not changed to the cloned repository, which would lead to an error when building the image. This was fixed by adding a `cd comfyui-docker` command after the `git clone` command.
- Updated the base image of the Dockerfile to the latest version of PyTorch (from PyTorch 2.7.1, CUDA 12.6, and cuDNN 9 to PyTorch 2.8.0, CUDA 12.9, and cuDNN 9).
- Updated the ComfyUI version to the latest version (from ComfyUI 0.3.40 to ComfyUI 0.3.49).
- Updated the ComfyUI Manager version to the latest version (from ComfyUI Manager 3.33 to ComfyUI Manager 3.35).
- This version of ComfyUI Docker was made possible by the contributions of [Patrick Kranz](@LokiMidgard), [Alex Reynolds](@primlock), and [Mustafa Hamade](@Mustafa-Hamade).

Closes issues #20, #23, and #25.