### PR TITLE
Enabled the Updating of ComfyUI in the Web UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,15 @@
 # Changelog
 
-## v0.6.0 (January 8, 2026)
+## v0.6.0 (January 9, 2026)
 
-- Updated the base image of the Dockerfile to the latest version of PyTorch (from PyTorch 2.8.0, CUDA 12.9, and cuDNN 9 to PyTorch 2.9.1, CUDA 13.0, and cuDNN 9).
+- Updated the base image of the Dockerfile to the latest version of PyTorch (from PyTorch 2.8.0, CUDA 12.9, and cuDNN 9 to PyTorch 2.9.1, CUDA 12.8, and cuDNN 9).
 - Updated the ComfyUI version to the latest version (from ComfyUI 0.3.49 to ComfyUI 0.8.2).
 - Updated the ComfyUI Manager version to the latest version (from ComfyUI Manager 3.35 to ComfyUI Manager 4.0.5).
 - Updated the versions of the checkout action, Python setup action, and attest build provenance action in the GitHub Actions workflow to their latest versions.
 - The outputs of ComfyUI are now stored outside of the container in a directory on the host system. This prevents the loss of outputs when the container is removed. The read me was updated to reflect this change.
 - A Docker Compose file was added to the repository to make running, managing, and updating ComfyUI Docker easier. The read me was updated to include instructions on how to use Docker Compose.
-- This version of ComfyUI Docker was made possible by the contributions of [Alex Marinov](@alex-marinov).
+- The ComfyUI and ComfyUI Manager repositories are now fully cloned instead of using the `--depth 1` option. Although this increases the size of the image, the size increase is negligible compared to the overall image size. This change now enables users to update ComfyUI and ComfyUI Manager from within the ComfyUI Manager interface, independent of the Docker image version.
+- This version of ComfyUI Docker was made possible by the contributions of [Patrick Kranz](@LokiMidgard) and [Alex Marinov](@alex-marinov).
 
 ## v0.5.0 (August 12, 2025)
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -6,4 +6,4 @@ The project was initially created and is maintained by [David Neumann](@lecode-o
 - [Alex Reynolds](@primlock) ([#22](https://github.com/lecode-official/comfyui-docker/pull/22))
 - [Chris TenHarmsel](@epchris) ([#13](https://github.com/lecode-official/comfyui-docker/pull/13))
 - [Mustafa Hamade](@Mustafa-Hamade) ([#20](https://github.com/lecode-official/comfyui-docker/issues/20))
-- [Patrick Kranz](@LokiMidgard) ([#21](https://github.com/lecode-official/comfyui-docker/pull/21))
+- [Patrick Kranz](@LokiMidgard) ([#21](https://github.com/lecode-official/comfyui-docker/pull/21), [#29](https://github.com/lecode-official/comfyui-docker/issues/29))

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ If you want to use the bleeding edge development version of the Docker image, yo
 ```shell
 git clone https://github.com/lecode-official/comfyui-docker.git
 cd comfyui-docker
-docker build --tag lecode/comfyui-docker:latest source
+docker build --tag comfyui-docker:latest source
 ```
 
 Now, a container can be started like so:
@@ -205,7 +205,7 @@ docker run \
     --publish 8188:8188 \
     --runtime nvidia \
     --gpus all \
-    lecode/comfyui-docker:latest
+    comfyui-docker:latest
 ```
 
 ## License

--- a/source/Dockerfile
+++ b/source/Dockerfile
@@ -2,7 +2,7 @@
 # Defines the versions of ComfyUI, ComfyUI Manager, and PyTorch to use
 ARG COMFYUI_VERSION=v0.8.2
 ARG COMFYUI_MANAGER_VERSION=4.0.5
-ARG PYTORCH_VERSION=2.9.1-cuda13.0-cudnn9-runtime
+ARG PYTORCH_VERSION=2.9.1-cuda12.8-cudnn9-runtime
 
 # This image is based on the latest official PyTorch image, because it already contains CUDA, CuDNN, and PyTorch
 FROM pytorch/pytorch:${PYTORCH_VERSION}
@@ -17,10 +17,9 @@ RUN apt update --assume-yes && \
     rm -rf /var/lib/apt/lists/*
 
 # Clones the ComfyUI repository and checks out the latest release
-RUN git clone --depth=1 https://github.com/Comfy-Org/ComfyUI.git /opt/comfyui && \
+RUN git clone https://github.com/Comfy-Org/ComfyUI.git /opt/comfyui && \
     cd /opt/comfyui && \
-    git fetch origin ${COMFYUI_VERSION} && \
-    git checkout FETCH_HEAD
+    git checkout ${COMFYUI_VERSION}
 
 # Clones the ComfyUI Manager repository and checks out the latest release; ComfyUI Manager is an extension for ComfyUI that enables users to install
 # custom nodes and download models directly from the ComfyUI interface; instead of installing it to "/opt/comfyui/custom_nodes/ComfyUI-Manager", which
@@ -28,10 +27,9 @@ RUN git clone --depth=1 https://github.com/Comfy-Org/ComfyUI.git /opt/comfyui &&
 # location upon startup; the reason for this is that the ComfyUI Manager must be installed in the same directory that it installs custom nodes to, but
 # this directory is mounted as a volume, so that the custom nodes are not installed inside of the container and are not lost when the container is
 # removed; this way, the custom nodes are installed on the host machine
-RUN git clone --depth=1 https://github.com/Comfy-Org/ComfyUI-Manager.git /opt/comfyui-manager && \
+RUN git clone https://github.com/Comfy-Org/ComfyUI-Manager.git /opt/comfyui-manager && \
     cd /opt/comfyui-manager && \
-    git fetch origin ${COMFYUI_MANAGER_VERSION} && \
-    git checkout FETCH_HEAD
+    git checkout ${COMFYUI_MANAGER_VERSION}
 
 # Installs the required Python packages for both ComfyUI and the ComfyUI Manager
 RUN pip install \


### PR DESCRIPTION
The ComfyUI and ComfyUI Manager repositories are now fully cloned instead of using the `--depth 1` option. Although this increases the size of the image, the size increase is negligible compared to the overall image size. This change now enables users to update ComfyUI and ComfyUI Manager from within the ComfyUI Manager interface, independent of the Docker image version.

Also, I downgraded the CUDA version from 13.0 to 12.8, as version 13.0 seems to be very new and at least Ubuntu 24.04 does not yet have the updated NVIDIA drivers in its repositories. I would have preferred to use CUDA 12.9, as this was the version that was used in the previous image, but for some reason the PyTorch team did not publish a CUDA 12.9 version of their Docker images. Therefore, I opted for CUDA 12.8, which is widely supported and should work well with most setups, even though some newer GPUs might benefit from using the latest CUDA version, as some optimizations might be missing in the older versions. Maybe I will produce multiple image versions with different CUDA versions in the future if there is demand for it.

Closes issue #29.