### PR TITLE
Release v0.6.3

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -232,8 +232,8 @@ jobs:
             type=semver,pattern={{version}},enable=${{ matrix.is_default }}
             type=semver,pattern={{version}}-comfyui-${{ matrix.comfyui_version }},enable=${{ matrix.is_default }}
             type=semver,pattern={{version}}-comfyui-${{ matrix.comfyui_version }}-comfyui-manager-${{ matrix.comfyui_manager_version }},enable=${{ matrix.is_default }}
-            type=semver,pattern={{major}}-comfyui-${{ matrix.comfyui_version }}-pytorch-${{ matrix.pytorch_version }}-cuda-${{ matrix.cuda_version }}-cudnn-${{ matrix.cudnn_version }}
-            type=semver,pattern={{major}}-comfyui-${{ matrix.comfyui_version }}-comfyui-manager-${{ matrix.comfyui_manager_version }}-pytorch-${{ matrix.pytorch_version }}-cuda-${{ matrix.cuda_version }}-cudnn-${{ matrix.cudnn_version }}
+            type=semver,pattern={{major}}-comfyui-${{ matrix.comfyui_version }}-pytorch-${{ matrix.pytorch_version }}-cuda-${{ matrix.cuda_version }}-cudnn-${{ matrix.cudnn_version }},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
+            type=semver,pattern={{major}}-comfyui-${{ matrix.comfyui_version }}-comfyui-manager-${{ matrix.comfyui_manager_version }}-pytorch-${{ matrix.pytorch_version }}-cuda-${{ matrix.cuda_version }}-cudnn-${{ matrix.cudnn_version }},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
             type=semver,pattern={{major}}.{{minor}}-comfyui-${{ matrix.comfyui_version }}-pytorch-${{ matrix.pytorch_version }}-cuda-${{ matrix.cuda_version }}-cudnn-${{ matrix.cudnn_version }}
             type=semver,pattern={{major}}.{{minor}}-comfyui-${{ matrix.comfyui_version }}-comfyui-manager-${{ matrix.comfyui_manager_version }}-pytorch-${{ matrix.pytorch_version }}-cuda-${{ matrix.cuda_version }}-cudnn-${{ matrix.cudnn_version }}
             type=semver,pattern={{version}}-comfyui-${{ matrix.comfyui_version }}-pytorch-${{ matrix.pytorch_version }}-cuda-${{ matrix.cuda_version }}-cudnn-${{ matrix.cudnn_version }}
@@ -255,6 +255,12 @@ jobs:
         with:
           context: source
           push: true
+          build-args: |
+            COMFYUI_VERSION=${{ matrix.comfyui_version }}
+            COMFYUI_MANAGER_VERSION=${{ matrix.comfyui_manager_version }}
+            PYTORCH_VERSION=${{ matrix.pytorch_version }}
+            CUDA_VERSION=${{ matrix.cuda_version }}
+            CUDNN_VERSION=${{ matrix.cudnn_version }}
           tags: ${{ steps.docker-image-metadata.outputs.tags }}
           labels: ${{ steps.docker-image-metadata.outputs.labels }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.6.3 (January 9, 2026)
+
+- This is another emergency release to fix an issue in v0.6.2 where the ComfyUI Docker image failed to build, because the build arguments for the versions of ComfyUI and ComfyUI Manager were defined before the `FROM` instruction in the Dockerfile. This only caused an issue now, because the "v" prefix in the ComfyUI version (e.g., "v0.8.2") was removed and then interpolated directly into the `git checkout` command, which led Git to fail with an error stating that the path spec "v" does not exist. The build arguments for the ComfyUI and ComfyUI Manager versions have now been moved to be defined after the `FROM` instruction in the Dockerfile.
+- The ComfyUI, ComfyUI Manager, PyTorch, CUDA, and cuDNN versions were not passed as build arguments in the GitHub Actions workflow file when building the Docker image. This has now been fixed by passing the respective `build-args` to the build-push action.
+- The tags with only the ComfyUI Docker major version that included the PyTorch, CUDA, and cuDNN versions were accidentally being created, even though the zero version should not have a tag with only the major version. This has now been fixed by adding the necessary condition to the tag creation step in the GitHub Actions workflow file.
+- Instead of using `apt`, which does not have a guaranteed stable interface, the `apt-get` command is now used in the Dockerfile to install dependencies. Also, the cached archives are now being removed after installing the packages in addition to the package lists to further reduce the image size.
+
 ## v0.6.2 (January 9, 2026)
 
 - This is an emergency release to fix an issue in v0.6.1 where the GitHub Actions workflow did not correctly set the output variable for the version combinations due to a typo in the variable name. This caused the build process to fail when trying to build images for different CUDA and cuDNN versions. The typo has been fixed by changing `version_combinations` to `version-combinations` in the relevant line of the workflow file.

--- a/source/Dockerfile
+++ b/source/Dockerfile
@@ -1,7 +1,5 @@
 
-# Defines the versions of ComfyUI, ComfyUI Manager, PyTorch, CUDA, and cuDNN to use
-ARG COMFYUI_VERSION=0.8.2
-ARG COMFYUI_MANAGER_VERSION=4.0.5
+# Defines build arguments for the versions of PyTorch, CUDA, and cuDNN to use
 ARG PYTORCH_VERSION=2.9.1
 ARG CUDA_VERSION=12.8
 ARG CUDNN_VERSION=9
@@ -9,19 +7,23 @@ ARG CUDNN_VERSION=9
 # This image is based on the latest official PyTorch image, because it already contains CUDA, CuDNN, and PyTorch
 FROM pytorch/pytorch:${PYTORCH_VERSION}-cuda${CUDA_VERSION}-cudnn${CUDNN_VERSION}-runtime
 
+# Defines build arguments for the versions of ComfyUI and ComfyUI Manager to use
+ARG COMFYUI_VERSION=0.8.2
+ARG COMFYUI_MANAGER_VERSION=4.0.5
+
 # Installs Git, because ComfyUI and the ComfyUI Manager are installed by cloning their respective Git repositories
-RUN apt update --assume-yes && \
-    apt install --assume-yes \
+RUN apt-get update --assume-yes && \
+    apt-get install --assume-yes \
         git \
         sudo \
         libgl1-mesa-glx \
         libglib2.0-0 && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/cache/apt/archives /var/lib/apt/lists/*
 
 # Clones the ComfyUI repository and checks out the latest release
 RUN git clone https://github.com/Comfy-Org/ComfyUI.git /opt/comfyui && \
     cd /opt/comfyui && \
-    git checkout v${COMFYUI_VERSION}
+    git checkout "v${COMFYUI_VERSION}"
 
 # Clones the ComfyUI Manager repository and checks out the latest release; ComfyUI Manager is an extension for ComfyUI that enables users to install
 # custom nodes and download models directly from the ComfyUI interface; instead of installing it to "/opt/comfyui/custom_nodes/ComfyUI-Manager", which


### PR DESCRIPTION
- This is another emergency release to fix an issue in v0.6.2 where the ComfyUI Docker image failed to build, because the build arguments for the versions of ComfyUI and ComfyUI Manager were defined before the `FROM` instruction in the Dockerfile. This only caused an issue now, because the "v" prefix in the ComfyUI version (e.g., "v0.8.2") was removed and then interpolated directly into the `git checkout` command, which led Git to fail with an error stating that the path spec "v" does not exist. The build arguments for the ComfyUI and ComfyUI Manager versions have now been moved to be defined after the `FROM` instruction in the Dockerfile.
- The ComfyUI, ComfyUI Manager, PyTorch, CUDA, and cuDNN versions were not passed as build arguments in the GitHub Actions workflow file when building the Docker image. This has now been fixed by passing the respective `build-args` to the build-push action.
- The tags with only the ComfyUI Docker major version that included the PyTorch, CUDA, and cuDNN versions were accidentally being created, even though the zero version should not have a tag with only the major version. This has now been fixed by adding the necessary condition to the tag creation step in the GitHub Actions workflow file.
- Instead of using `apt`, which does not have a guaranteed stable interface, the `apt-get` command is now used in the Dockerfile to install dependencies. Also, the cached archives are now being removed after installing the packages in addition to the package lists to further reduce the image size.

Closes issue #43.