### PR TITLE
Update bundled ComfyUI image components

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Updated the bundled ComfyUI version from 0.8.2 to 0.22.2.
+- Updated the bundled ComfyUI Manager version from 4.0.5 to 4.2.1.
+- Updated the read me examples to describe the current tag formats without hard-coding outdated release values.
+
 ## v0.6.3 (January 9, 2026)
 
 - This is another emergency release to fix an issue in v0.6.2 where the ComfyUI Docker image failed to build, because the build arguments for the versions of ComfyUI and ComfyUI Manager were defined before the `FROM` instruction in the Dockerfile. This only caused an issue now, because the "v" prefix in the ComfyUI version (e.g., "v0.8.2") was removed and then interpolated directly into the `git checkout` command, which led Git to fail with an error stating that the path spec "v" does not exist. The build arguments for the ComfyUI and ComfyUI Manager versions have now been moved to be defined after the `FROM` instruction in the Dockerfile.

--- a/README.md
+++ b/README.md
@@ -101,10 +101,10 @@ CUSTOM_NODES_PATH=<path/to/custom/nodes/folder>
 OUTPUT_PATH=<path/to/output/folder>
 ```
 
-The Dockerfile uses the ComfyUI Docker image with the `latest` tag. A different tag can be specified using the `IMAGE_TAG` environment variable. Again, the image tag can be set permanently in a `.env` file. For a full list of the available image tags, please refer to the [image tags](#available-image-tags) section. Assuming you have already created a `.env` file, you can run the following command to use the `0.6.1` tag by appending the `IMAGE_TAG` variable to the existing `.env` file:
+The Dockerfile uses the ComfyUI Docker image with the `latest` tag. A different tag can be specified using the `IMAGE_TAG` environment variable. Again, the image tag can be set permanently in a `.env` file. For a full list of the available image tags, please refer to the [image tags](#available-image-tags) section. Assuming you have already created a `.env` file, you can run the following command to use a specific release tag by appending the `IMAGE_TAG` variable to the existing `.env` file:
 
 ```shell
-echo "IMAGE_TAG=0.6.1" >> .env
+echo "IMAGE_TAG=<release-tag>" >> .env
 ```
 
 Normally, the user inside a Docker container is `root`, which means that the files that are written from the container to the host system are also owned by `root`. To avoid this, ComfyUI Docker creates a new user inside the container. By default, running the Docker Compose file will create a user and group with the IDs `1000` and `1000`, respectively. Most Linux systems have the first user created with these IDs. If your user has different IDs, you can change them using the `USER_ID` and `GROUP_ID` environment variables. To permanently set these environment variables, you may again use a `.env` file alongside the `compose.yml` file to specify the correct IDs. You can find out your user and group IDs by running `id -u` and `id -g` in your terminal. Assuming you have already created a `.env` file, you can run the following commands to append the user and group IDs to the existing `.env` file:
@@ -153,10 +153,10 @@ docker compose up --detach --force-recreate
 The ComfyUI Docker image is available with different tags. The available tags are:
 
 - `latest`: The latest stable version of ComfyUI Docker. This will use the latest versions of ComfyUI, ComfyUI Manager, and PyTorch available at the time of the image build. It will not always use the most recent version of CUDA and cuDNN, but may instead use a slightly older, but more broadly compatible version.
-- `0.6`, `0.6.1`: These tags will always use the specific version of ComfyUI Docker, and the latest versions of ComfyUI, ComfyUI Manager and PyTorch available at the time of the image build. It will not always use the most recent version of CUDA and cuDNN, but may instead use a slightly older, but more broadly compatible version.
-- `0.6-comfyui-0.8.2`, `0.6.1-comfyui-0.8.2`: These tags will always use the specific versions of ComfyUI Docker and ComfyUI, and the latest versions of ComfyUI Manager and PyTorch available at the time of the image build. It will not always use the most recent version of CUDA and cuDNN, but may instead use a slightly older, but more broadly compatible version.
-- `0.6-comfyui-0.8.2-comfyui-manager-4.0.5`, `0.6.0-comfyui-0.8.2-comfyui-manager-4.0.5`: These tags will always use the specific versions of ComfyUI Docker, ComfyUI, and ComfyUI Manager, and the latest version of PyTorch available at the time of the image build. It will not always use the most recent version of CUDA and cuDNN, but may instead use a slightly older, but more broadly compatible version.
-- `0.6-comfyui-0.8.2-comfyui-manager-4.0.5-pytorch-2.9.1-cuda-12.8-cudnn-9`, `0.6.1-comfyui-0.8.2-comfyui-manager-4.0.5-pytorch-2.9.1-cuda-12.8-cudnn-9`: These tags will always use the specific versions of ComfyUI Docker, ComfyUI, ComfyUI Manager, PyTorch, CUDA, and cuDNN.
+- `<major>.<minor>`, `<major>.<minor>.<patch>`: These tags will always use the specific version of ComfyUI Docker, and the latest versions of ComfyUI, ComfyUI Manager, and PyTorch available at the time of the image build. They will not always use the most recent version of CUDA and cuDNN, but may instead use a slightly older, but more broadly compatible version.
+- `<docker-version>-comfyui-<comfyui-version>`: These tags will always use the specific versions of ComfyUI Docker and ComfyUI, and the latest versions of ComfyUI Manager and PyTorch available at the time of the image build. They will not always use the most recent version of CUDA and cuDNN, but may instead use a slightly older, but more broadly compatible version.
+- `<docker-version>-comfyui-<comfyui-version>-comfyui-manager-<manager-version>`: These tags will always use the specific versions of ComfyUI Docker, ComfyUI, and ComfyUI Manager, and the latest version of PyTorch available at the time of the image build. They will not always use the most recent version of CUDA and cuDNN, but may instead use a slightly older, but more broadly compatible version.
+- `<docker-version>-comfyui-<comfyui-version>-comfyui-manager-<manager-version>-pytorch-<pytorch-version>-cuda-<cuda-version>-cudnn-<cudnn-version>`: These tags will always use the specific versions of ComfyUI Docker, ComfyUI, ComfyUI Manager, PyTorch, CUDA, and cuDNN.
 - `sha-<short-commit-sha>`: These tags point to ComfyUI Docker that were build from the specific commit. They will always use the versions of ComfyUI Docker, ComfyUI, ComfyUI Manager, and PyTorch that were the most recent at the time of the image build. It will not always use the most recent version of CUDA and cuDNN available at the time of the build, but may instead use a slightly older, but more broadly compatible version.
 
 > [!WARNING]
@@ -230,4 +230,4 @@ docker run \
 
 ## License
 
-The ComfyUI Docker image is licensed under the [MIT License](LICENSE). [ComfyUI](https://github.com/comfyanonymous/ComfyUI/blob/master/LICENSE) and the [ComfyUI Manager](https://github.com/ltdrdata/ComfyUI-Manager/blob/main/LICENSE.txt) are both licensed under the GPL 3.0 license.
+The ComfyUI Docker image is licensed under the [MIT License](LICENSE). [ComfyUI](https://github.com/Comfy-Org/ComfyUI/blob/master/LICENSE) and the [ComfyUI Manager](https://github.com/Comfy-Org/ComfyUI-Manager/blob/main/LICENSE.txt) are both licensed under the GPL 3.0 license.

--- a/source/Dockerfile
+++ b/source/Dockerfile
@@ -8,8 +8,8 @@ ARG CUDNN_VERSION=9
 FROM pytorch/pytorch:${PYTORCH_VERSION}-cuda${CUDA_VERSION}-cudnn${CUDNN_VERSION}-runtime
 
 # Defines build arguments for the versions of ComfyUI and ComfyUI Manager to use
-ARG COMFYUI_VERSION=0.8.2
-ARG COMFYUI_MANAGER_VERSION=4.0.5
+ARG COMFYUI_VERSION=0.22.2
+ARG COMFYUI_MANAGER_VERSION=4.2.1
 
 # Installs Git, because ComfyUI and the ComfyUI Manager are installed by cloning their respective Git repositories
 RUN apt-get update --assume-yes && \
@@ -51,4 +51,5 @@ EXPOSE 8188
 # mounted to the container and symlink the ComfyUI Manager to the correct directory; it will also create a user with the same UID and GID as the user
 # that started the container, so that the files created by the container are owned by the user that started the container and not the root user
 ADD entrypoint.sh /entrypoint.sh
+RUN sed -i 's/\r$//' /entrypoint.sh && chmod +x /entrypoint.sh
 ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]


### PR DESCRIPTION
## Summary
- update the bundled ComfyUI version to 0.22.2 and ComfyUI Manager to 4.2.1
- make the image resilient to CRLF line endings in entrypoint.sh by normalizing the script during the Docker build
- replace stale README tag examples with generic tag formats and update the upstream project license links

## Validation
- built the image locally with `docker build -t comfyui-docker:whatnick-test source`
- started the container successfully far enough to reach ComfyUI startup on a non-GPU host after fixing the CRLF issue
- verified the remaining startup failure on the test host is the expected `Found no NVIDIA driver on your system` runtime error