### PR TITLE
Update Dockerfile and entrypoint to bump versions of PyTorch, CUDA, and ComfyUI.

### DIFF
--- a/source/Dockerfile
+++ b/source/Dockerfile
@@ -1,22 +1,22 @@
 
 # Defines build arguments for the versions of PyTorch, CUDA, and cuDNN to use
-ARG PYTORCH_VERSION=2.9.1
-ARG CUDA_VERSION=12.8
+ARG PYTORCH_VERSION=2.12.0
+ARG CUDA_VERSION=13.0
 ARG CUDNN_VERSION=9
 
 # This image is based on the latest official PyTorch image, because it already contains CUDA, CuDNN, and PyTorch
 FROM pytorch/pytorch:${PYTORCH_VERSION}-cuda${CUDA_VERSION}-cudnn${CUDNN_VERSION}-runtime
 
 # Defines build arguments for the versions of ComfyUI and ComfyUI Manager to use
-ARG COMFYUI_VERSION=0.8.2
-ARG COMFYUI_MANAGER_VERSION=4.0.5
+ARG COMFYUI_VERSION=0.22.0
 
 # Installs Git, because ComfyUI and the ComfyUI Manager are installed by cloning their respective Git repositories
 RUN apt-get update --assume-yes && \
     apt-get install --assume-yes \
         git \
         sudo \
-        libgl1-mesa-glx \
+        libgl1 \
+        libglx-mesa0 \
         libglib2.0-0 && \
     rm -rf /var/cache/apt/archives /var/lib/apt/lists/*
 
@@ -25,20 +25,12 @@ RUN git clone https://github.com/Comfy-Org/ComfyUI.git /opt/comfyui && \
     cd /opt/comfyui && \
     git checkout "v${COMFYUI_VERSION}"
 
-# Clones the ComfyUI Manager repository and checks out the latest release; ComfyUI Manager is an extension for ComfyUI that enables users to install
-# custom nodes and download models directly from the ComfyUI interface; instead of installing it to "/opt/comfyui/custom_nodes/ComfyUI-Manager", which
-# is the directory it is meant to be installed in, it is installed to its own directory; the entrypoint will symlink the directory to the correct
-# location upon startup; the reason for this is that the ComfyUI Manager must be installed in the same directory that it installs custom nodes to, but
-# this directory is mounted as a volume, so that the custom nodes are not installed inside of the container and are not lost when the container is
-# removed; this way, the custom nodes are installed on the host machine
-RUN git clone https://github.com/Comfy-Org/ComfyUI-Manager.git /opt/comfyui-manager && \
-    cd /opt/comfyui-manager && \
-    git checkout ${COMFYUI_MANAGER_VERSION}
+# Removed ComfyUI Manager since it's now bundled with ComfyUI.
 
 # Installs the required Python packages for both ComfyUI and the ComfyUI Manager
-RUN pip install \
+RUN pip install --break-system-packages \
     --requirement /opt/comfyui/requirements.txt \
-    --requirement /opt/comfyui-manager/requirements.txt
+    --requirement /opt/comfyui/manager_requirements.txt
 
 # Sets the working directory to the ComfyUI directory
 WORKDIR /opt/comfyui

--- a/source/entrypoint.sh
+++ b/source/entrypoint.sh
@@ -59,8 +59,8 @@ done
 if [ -z "$USER_ID" ] || [ -z "$GROUP_ID" ];
 then
     echo "Running container as $USER..."
-    exec /opt/conda/bin/python main.py \
-        --enable-manager
+    exec python main.py \
+        --enable-manager \
         --port 8188 \
         --listen 0.0.0.0 \
         --disable-auto-launch \
@@ -74,8 +74,8 @@ else
 
     echo "Running container as comfyui-user ($USER_ID:$GROUP_ID)..."
     sudo --set-home --preserve-env=PATH --user \#$USER_ID \
-        /opt/conda/bin/python main.py \
-            --enable-manager
+        python main.py \
+            --enable-manager \
             --port 8188 \
             --listen 0.0.0.0 \
             --disable-auto-launch \

--- a/source/entrypoint.sh
+++ b/source/entrypoint.sh
@@ -3,6 +3,8 @@
 # Creates the directories for the models inside of the volume that is mounted from the host
 echo "Creating directories for models..."
 MODEL_DIRECTORIES=(
+    "audio_encoders"
+    "background_removal"
     "checkpoints"
     "clip"
     "clip_vision"
@@ -11,9 +13,14 @@ MODEL_DIRECTORIES=(
     "diffusers"
     "diffusion_models"
     "embeddings"
+    "frame_interpolation"
+    "geometry_estimation"
     "gligen"
     "hypernetworks"
+    "latent_upscale_models"
     "loras"
+    "model_patches"
+    "optical_flow"
     "photomaker"
     "style_models"
     "text_encoders"
@@ -26,27 +33,17 @@ for MODEL_DIRECTORY in ${MODEL_DIRECTORIES[@]}; do
     mkdir -p /opt/comfyui/models/$MODEL_DIRECTORY
 done
 
-# Creates the symlink for the ComfyUI Manager to the custom nodes directory, which is also mounted from the host
-echo "Creating symlink for ComfyUI Manager..."
-rm --force /opt/comfyui/custom_nodes/ComfyUI-Manager
-ln -s \
-    /opt/comfyui-manager \
-    /opt/comfyui/custom_nodes/ComfyUI-Manager
-
 # The custom nodes that were installed using the ComfyUI Manager may have requirements of their own, which are not installed when the container is
 # started for the first time; this loops over all custom nodes and installs the requirements of each custom node
 echo "Installing requirements for custom nodes..."
 for CUSTOM_NODE_DIRECTORY in /opt/comfyui/custom_nodes/*;
 do
-    if [ "$CUSTOM_NODE_DIRECTORY" != "/opt/comfyui/custom_nodes/ComfyUI-Manager" ];
+    if [ -f "$CUSTOM_NODE_DIRECTORY/requirements.txt" ];
     then
-        if [ -f "$CUSTOM_NODE_DIRECTORY/requirements.txt" ];
-        then
-            CUSTOM_NODE_NAME=${CUSTOM_NODE_DIRECTORY##*/}
-            CUSTOM_NODE_NAME=${CUSTOM_NODE_NAME//[-_]/ }
-            echo "Installing requirements for $CUSTOM_NODE_NAME..."
-            pip install --requirement "$CUSTOM_NODE_DIRECTORY/requirements.txt"
-        fi
+        CUSTOM_NODE_NAME=${CUSTOM_NODE_DIRECTORY##*/}
+        CUSTOM_NODE_NAME=${CUSTOM_NODE_NAME//[-_]/ }
+        echo "Installing requirements for $CUSTOM_NODE_NAME..."
+        pip install --break-system-packages --requirement "$CUSTOM_NODE_DIRECTORY/requirements.txt"
     fi
 done
 
@@ -63,6 +60,7 @@ if [ -z "$USER_ID" ] || [ -z "$GROUP_ID" ];
 then
     echo "Running container as $USER..."
     exec /opt/conda/bin/python main.py \
+        --enable-manager
         --port 8188 \
         --listen 0.0.0.0 \
         --disable-auto-launch \
@@ -72,12 +70,12 @@ else
     getent group $GROUP_ID > /dev/null 2>&1 || groupadd --gid $GROUP_ID comfyui-user
     id -u $USER_ID > /dev/null 2>&1 || useradd --uid $USER_ID --gid $GROUP_ID --create-home comfyui-user
     chown --recursive $USER_ID:$GROUP_ID /opt/comfyui
-    chown --recursive $USER_ID:$GROUP_ID /opt/comfyui-manager
     export PATH=$PATH:/home/comfyui-user/.local/bin
 
     echo "Running container as comfyui-user ($USER_ID:$GROUP_ID)..."
     sudo --set-home --preserve-env=PATH --user \#$USER_ID \
         /opt/conda/bin/python main.py \
+            --enable-manager
             --port 8188 \
             --listen 0.0.0.0 \
             --disable-auto-launch \


### PR DESCRIPTION
Hey there, 

Sorry, saw that you are working on this, but I figured I'd push some of the changes I made in my own branch to get this up to date for you in case they were helpful.

Summary of changes

- Bumped PyTorch, Cuda versions to latest stable
- Bumped ComfyUI to latest stable
- Removed ComfyUI Manager separate installation and setup as it's now bundled with ComfyU

You can test the updates with my image published to GitHub through my fork of this. All ComfyUI Manager, custom nodes/installation works. I was able to generate and work through the program without any issues. 

Since the ComfyUI listens on 0.0.0.0, you do need to update the network mode/security within the ComfyUI files if you want to install custom nodes or update through the UI. I wasn't able to have that set up with the entrypoint.sh, since most of those files aren't created until first launch. So therefore I updated the read me on mine with a command that would easily change the network/security mode. Once the command is ran, you just need to restart the container or in the UI to get the new settings to take hold.

One note: I know Python now likes venv for installation but I wasn't able to get that working/didn't want another level of virtualization,, so I went with --break-system-packages override. 